### PR TITLE
writeListToKafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>org.cloudera.spark.streaming.kafka</groupId>
   <artifactId>spark-kafka-writer</artifactId>
   <name>API to write from Spark and Spark Streaming to Kafka</name>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/DStreamKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/DStreamKafkaWriter.scala
@@ -18,6 +18,8 @@ package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
 
+import org.apache.kafka.clients.producer.ProducerRecord
+
 import scala.reflect.ClassTag
 
 import kafka.producer.KeyedMessage
@@ -41,7 +43,7 @@ class DStreamKafkaWriter[T: ClassTag](@transient dstream: DStream[T]) extends Ka
    *
    */
   override def writeToKafka[K, V](producerConfig: Properties,
-    serializerFunc: T => KeyedMessage[K, V]): Unit = {
+    serializerFunc: T => ProducerRecord[K, V]): Unit = {
     dstream.foreachRDD { rdd =>
       val rddWriter = new RDDKafkaWriter[T](rdd)
       rddWriter.writeToKafka(producerConfig, serializerFunc)

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/JavaDStreamKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/JavaDStreamKafkaWriter.scala
@@ -8,6 +8,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.streaming.api.java.JavaDStream
 
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -31,6 +32,12 @@ class JavaDStreamKafkaWriter[T](dstream: JavaDStream[T])(implicit val classTag: 
     producerConfig: Properties,
     function1: Function[T, ProducerRecord[K,V]]): Unit = {
     dstreamWriter.writeToKafka(producerConfig, t => function1.call(t))
+  }
+
+  def writeListToKafka[K, V](
+                          producerConfig: Properties,
+                          function1: Function[T, java.util.List[ProducerRecord[K,V]]]): Unit = {
+    dstreamWriter.writeListToKafka(producerConfig, t => function1.call(t))
   }
 }
 

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/JavaDStreamKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/JavaDStreamKafkaWriter.scala
@@ -1,11 +1,10 @@
 package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.spark.api.java.function.Function
 
 import scala.reflect.ClassTag
-
-import kafka.producer.KeyedMessage
 
 import org.apache.spark.streaming.api.java.JavaDStream
 
@@ -30,7 +29,7 @@ class JavaDStreamKafkaWriter[T](dstream: JavaDStream[T])(implicit val classTag: 
 
   def writeToKafka[K, V](
     producerConfig: Properties,
-    function1: Function[T, KeyedMessage[K,V]]): Unit = {
+    function1: Function[T, ProducerRecord[K,V]]): Unit = {
     dstreamWriter.writeToKafka(producerConfig, t => function1.call(t))
   }
 }

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/JavaRDDKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/JavaRDDKafkaWriter.scala
@@ -32,6 +32,13 @@ class JavaRDDKafkaWriter[T](rdd: JavaRDD[T])(implicit val classTag: ClassTag[T])
       function1: Function[T, ProducerRecord[K,V]]): Unit = {
     rddWriter.writeToKafka(producerConfig, t => function1.call(t))
   }
+
+  def writeListToKafka[K, V](
+      producerConfig: Properties,
+      function1: Function[T, java.util.List[ProducerRecord[K,V]]]): Unit = {
+    rddWriter.writeListToKafka(producerConfig, t => function1.call(t))
+  }
+
 }
 
 object JavaRDDKafkaWriterFactory {

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/JavaRDDKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/JavaRDDKafkaWriter.scala
@@ -17,11 +17,10 @@
 package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.spark.api.java.function.Function
 
 import scala.reflect.ClassTag
-
-import kafka.producer.KeyedMessage
 
 import org.apache.spark.api.java.JavaRDD
 
@@ -30,7 +29,7 @@ class JavaRDDKafkaWriter[T](rdd: JavaRDD[T])(implicit val classTag: ClassTag[T])
 
   def writeToKafka[K, V](
       producerConfig: Properties,
-      function1: Function[T, KeyedMessage[K,V]]): Unit = {
+      function1: Function[T, ProducerRecord[K,V]]): Unit = {
     rddWriter.writeToKafka(producerConfig, t => function1.call(t))
   }
 }

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/KafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/KafkaWriter.scala
@@ -97,4 +97,17 @@ abstract class KafkaWriter[T: ClassTag]() {
    *
    */
   def writeToKafka[K, V](producerConfig: Properties, serializerFunc: T => ProducerRecord[K, V]): Unit
+
+  /**
+   * Same as @see(KafkaWriter#writeToKafka) except this allows a List of ProducerRecords, allowing 0-N
+   * messages to be sent.
+   *
+   * @param producerConfig  The configuration that can be used to connect to Kafka
+   * @param serializerFunc  The function to convert the data from the stream into Kafka
+   *                        List[[ProducerRecord]]s.
+   * @tparam K              The type of the key
+   * @tparam V              The type of the value
+   * @see                   KafkaWriter#writeToKafka
+   */
+  def writeListToKafka[K, V](producerConfig: Properties, serializerFunc: (T) => java.util.List[ProducerRecord[K, V]]): Unit
 }

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/KafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/KafkaWriter.scala
@@ -19,7 +19,7 @@ package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
 
-import kafka.producer.{ProducerConfig, KeyedMessage, Producer}
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream.DStream
 
@@ -87,14 +87,14 @@ abstract class KafkaWriter[T: ClassTag]() {
    * the DStream is passed into this function, all data coming from the DStream is written out to
    * Kafka. The properties instance takes the configuration required to connect to the Kafka
    * brokers in the standard Kafka format. The serializerFunc is a function that converts each
-   * element of the RDD to a Kafka [[KeyedMessage]]. This closure should be serializable - so it
+   * element of the RDD to a Kafka [[ProducerRecord]]. This closure should be serializable - so it
    * should use only instances of Serializables.
    * @param producerConfig The configuration that can be used to connect to Kafka
    * @param serializerFunc The function to convert the data from the stream into Kafka
-   *                       [[KeyedMessage]]s.
+   *                       [[ProducerRecord]]s.
    * @tparam K The type of the key
    * @tparam V The type of the value
    *
    */
-  def writeToKafka[K, V](producerConfig: Properties, serializerFunc: T => KeyedMessage[K, V]): Unit
+  def writeToKafka[K, V](producerConfig: Properties, serializerFunc: T => ProducerRecord[K, V]): Unit
 }

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/ProducerCache.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/ProducerCache.scala
@@ -18,19 +18,19 @@ package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
 
-import scala.collection.mutable
+import org.apache.kafka.clients.producer.KafkaProducer
 
-import kafka.producer.{ProducerConfig, Producer}
+import scala.collection.mutable
 
 object ProducerCache {
 
   private val producers = new mutable.HashMap[Properties, Any]()
 
-  def getProducer[K,V](config: Properties): Producer[K, V] = {
+  def getProducer[K,V](config: Properties): KafkaProducer[K, V] = {
     producers.getOrElse(config, {
-      val producer = new Producer[K, V](new ProducerConfig(config))
+      val producer = new KafkaProducer[K, V](config)
       producers(config) = producer
       producer
-    }).asInstanceOf[Producer[K, V]]
+    }).asInstanceOf[KafkaProducer[K, V]]
   }
 }

--- a/src/main/scala/org/cloudera/spark/streaming/kafka/RDDKafkaWriter.scala
+++ b/src/main/scala/org/cloudera/spark/streaming/kafka/RDDKafkaWriter.scala
@@ -18,9 +18,9 @@ package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
 
-import scala.reflect.ClassTag
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 
-import kafka.producer.{KeyedMessage, Producer}
+import scala.reflect.ClassTag
 
 import org.apache.spark.rdd.RDD
 
@@ -31,20 +31,20 @@ class RDDKafkaWriter[T: ClassTag](@transient rdd: RDD[T]) extends KafkaWriter[T]
    * the DStream is passed into this function, all data coming from the DStream is written out to
    * Kafka. The properties instance takes the configuration required to connect to the Kafka
    * brokers in the standard Kafka format. The serializerFunc is a function that converts each
-   * element of the RDD to a Kafka [[KeyedMessage]]. This closure should be serializable - so it
+   * element of the RDD to a Kafka [[ProducerRecord]]. This closure should be serializable - so it
    * should use only instances of Serializables.
    * @param producerConfig The configuration that can be used to connect to Kafka
    * @param serializerFunc The function to convert the data from the stream into Kafka
-   *                       [[KeyedMessage]]s.
+   *                       [[ProducerRecord]]s.
    * @tparam K The type of the key
    * @tparam V The type of the value
    *
    */
   override def writeToKafka[K, V](producerConfig: Properties,
-    serializerFunc: (T) => KeyedMessage[K, V]): Unit = {
+    serializerFunc: (T) => ProducerRecord[K, V]): Unit = {
     rdd.foreachPartition(events => {
-      val producer: Producer[K, V] = ProducerCache.getProducer(producerConfig)
-      producer.send(events.map(serializerFunc).toArray: _*)
+      val producer: KafkaProducer[K, V] = ProducerCache.getProducer(producerConfig)
+      events.map(serializerFunc).foreach(producer.send)
     })
   }
 }

--- a/src/test/java/org/cloudera/spark/streaming/kafka/TestJavaKafkaOutputDStreamList.java
+++ b/src/test/java/org/cloudera/spark/streaming/kafka/TestJavaKafkaOutputDStreamList.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.cloudera.spark.streaming.kafka;
+
+import com.google.common.collect.Lists;
+import kafka.message.MessageAndMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.cloudera.spark.streaming.kafka.util.TestUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+public class TestJavaKafkaOutputDStreamList {
+    private TestUtil testUtil = TestUtil.getInstance();
+    // Name of the framework for Spark context
+    private String framework = this.getClass().getSimpleName();
+
+    // Master for Spark context
+    private String master = "local[2]";
+    private SparkConf conf = new SparkConf()
+            .setMaster(master)
+            .setAppName(framework);
+    private JavaStreamingContext ssc = new JavaStreamingContext(conf, new Duration(2000l));
+
+    @Before
+    public void setup() {
+        testUtil.prepare();
+        List<String> topics = new ArrayList<String>(3);
+        topics.add("default");
+        topics.add("static");
+        topics.add("custom");
+        testUtil.initTopicList(topics);
+    }
+
+    @After
+    public void tearDown() {
+        testUtil.tearDown();
+    }
+
+    @Test
+    public void testKafkaDStream() throws Exception {
+        Queue<JavaRDD<String>> toBe = new LinkedList<JavaRDD<String>>();
+        int j = 0;
+        while (j < 9) {
+            toBe.add(ssc.sc().parallelize(Lists.newArrayList(
+                    Integer.toString(j), Integer.toString(j + 1), Integer.toString(j + 2))));
+            j += 3;
+        }
+        JavaDStream<String> instream = ssc.queueStream(toBe);
+        Properties producerConf = new Properties();
+        producerConf.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        producerConf.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+        producerConf.put("bootstrap.servers", testUtil.getKafkaServerUrl());
+        producerConf.put("request.required.acks", "1");
+        JavaDStreamKafkaWriter<String> writer = JavaDStreamKafkaWriterFactory.fromJavaDStream(instream);
+        writer.writeListToKafka(producerConf, new ListProcessingFunc());
+
+        ssc.start();
+        Thread.sleep(10000);
+
+
+        int i = 0;
+        Set<String> expectedResults =
+                new TreeSet<String>(Lists.newArrayList("0", "1", "2", "3", "4", "5", "6", "7", "8"));
+        Set<String> actualResults = new TreeSet<String>();
+        boolean moreMessages = true;
+        while (moreMessages) {
+            MessageAndMetadata msg = testUtil.getNextMessageFromConsumer("default");
+            if (msg != null) {
+                String fetchedMsg = new String((byte[]) msg.message());
+                Assert.assertNotNull(fetchedMsg);
+                actualResults.add(fetchedMsg);
+            } else {
+                moreMessages = false;
+            }
+        }
+        Assert.assertEquals(expectedResults, actualResults);
+    }
+}
+
+class ListProcessingFunc implements Function<String, List<ProducerRecord<String, byte[]>>> {
+
+    public List<ProducerRecord<String, byte[]>> call(String in) throws Exception {
+
+        List<ProducerRecord<String, byte[]>> retList = new ArrayList<ProducerRecord<String, byte[]>>();
+        retList.add(new ProducerRecord<String, byte[]>("default", null, in.getBytes()));
+        return retList;
+
+    }
+}

--- a/src/test/scala/org/cloudera/spark/streaming/kafka/TestKafkaOutputDStream.scala
+++ b/src/test/scala/org/cloudera/spark/streaming/kafka/TestKafkaOutputDStream.scala
@@ -18,7 +18,7 @@ package org.cloudera.spark.streaming.kafka
 
 import java.util.Properties
 
-import kafka.producer.KeyedMessage
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.cloudera.spark.streaming.kafka.util.TestUtil
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
@@ -27,7 +27,6 @@ import org.junit.{After, Before, Test, Assert}
 import org.cloudera.spark.streaming.kafka.KafkaWriter._
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
 
 class TestKafkaOutputDStream {
   private val testUtil: TestUtil = TestUtil.getInstance
@@ -67,12 +66,12 @@ class TestKafkaOutputDStream {
     }
     val instream = ssc.queueStream(toBe)
     val producerConf = new Properties()
-    producerConf.put("serializer.class", "kafka.serializer.DefaultEncoder")
-    producerConf.put("key.serializer.class", "kafka.serializer.StringEncoder")
-    producerConf.put("metadata.broker.list", testUtil.getKafkaServerUrl)
+    producerConf.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    producerConf.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer")
+    producerConf.put("bootstrap.servers", testUtil.getKafkaServerUrl)
     producerConf.put("request.required.acks", "1")
     instream.writeToKafka(producerConf,
-      (x: String) => new KeyedMessage[String,Array[Byte]]("default", null,x.getBytes))
+      (x: String) => new ProducerRecord[String,Array[Byte]]("default", null,x.getBytes))
       ssc.start()
 
     Thread.sleep(10000)


### PR DESCRIPTION
As discussed in the original design document, Added an option to send a List of ProducerRecords to Kafka, allowing for 0-N records to be sent to X topics. Also using the new producer API.